### PR TITLE
fix: bugfix keep umask value same as v20 when shift to new user.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,6 @@ override_dh_auto_configure:
 		--enable-isadir=/usr/lib/security \
 		--with-systemdunitdir=/usr/lib/systemd/system \
 		--disable-nis \
-		--enable-usergroups \
 		$(CONFIGURE_OPTS)
 
 # .install files don't have "except for" handling, so we need to exclude


### PR DESCRIPTION
keep umask value same as v20 when shift to new user.
