### PR TITLE
fix: CVE-2025-6020 - pam_namespace privilege escalation via symlink attacks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+pam (1.5.3-9deepin9) unstable; urgency=medium
+
+  * fix CVE-2025-6020 - pam_namespace privilege escalation via symlink
+    attacks  Backport of upstream commit 976c2007 for PAM 1.7.1: Remove
+    unnecessary group ownership check and simplify directory permission
+    validation to prevent symlink attacks.  Changed from:   st.st_uid !=
+    0 || st.st_gid != 0 || (st.st_mode & S_IWOTH) To:   st.st_uid != 0
+    || (st.st_mode & (S_IWGRP|S_IWOTH))  References:   -
+    https://github.com/linux-pam/linux-pam/security/advisories/GHSA-f9p8-
+    gjr4-j9gx   - https://github.com/linux-pam/linux-
+    pam/commit/976c20079358d133514568fc7fd95c02df8b5773   -
+    https://security-tracker.debian.org/tracker/CVE-2025-6020
+
+ -- hudeng <hudeng@deepin.org>  Wed, 04 Feb 2026 11:17:44 +0800
+
 pam (1.5.3-9deepin8) unstable; urgency=medium
 
   * set default cipher sm3crypt in common-password

--- a/debian/patches/cve_2025_6020.patch
+++ b/debian/patches/cve_2025_6020.patch
@@ -1,37 +1,61 @@
 Description: pam_namespace: fix privilege escalation via symlink attacks (CVE-2025-6020)
  The protect_dir() function in pam_namespace may access user-controlled paths
  without proper O_NOFOLLOW protection, allowing local users to elevate their
- privileges via symlink attacks. This minimal backport improves the logic for
- detecting when to enable O_NOFOLLOW protection and validates that only
- root-owned directories without loose permissions can be followed.
+ privileges via symlink attacks.
  .
- The vulnerability occurs because the function may follow symlinks when
- traversing paths that contain user-controlled components. The fix improves
- the validation logic to ensure we only follow symlinks in directories that
- are owned by root and not group-writable or world-writable.
+ Upstream fix commit 976c2007 (for PAM 1.7.1): Remove unnecessary group
+ ownership check and simplify to check if directory is group-writable or
+ world-writable regardless of group ownership.
  .
- This is a minimal backport fix for PAM 1.5.3, adapted from the more comprehensive
- rewrite in PAM 1.7.1.
+ The original code checked if the directory was not owned by root (uid != 0
+ or gid != 0) OR if it was world-writable. This was insufficient because
+ a directory owned by root (gid=0) but group-writable could still allow
+ symlink attacks - any user who is member of the root group can modify symlinks.
+ .
+ The fix changes the logic from:
+   st.st_uid != 0 || st.st_gid != 0 || (st.st_mode & S_IWOTH)
+ To:
+   st.st_uid != 0 || (st.st_mode & (S_IWGRP|S_IWOTH))
+ 
+ This ensures proper O_NOFOLLOW protection when traversing directory paths
+ that contain user-controlled components or directories with loose permissions.
+ .
+ Complete upstream fix consists of 3 commits:
+  - 475bd60c: "pam_namespace: fix potential privilege escalation"
+  - 592d84e: "pam_namespace: add flags to indicate path safety"
+  - 976c2007: "pam_namespace: secure_opendir: do not look at the group ownership"
+ .
+ This is a minimal backport for PAM 1.5.3. For complete protection,
+ upstream recommends upgrading to PAM 1.7.1 which uses file-descriptor
+ based operations (not compatible with this version).
+ .
+ References:
+  - https://github.com/linux-pam/linux-pam/security/advisories/GHSA-f9p8-gjr4-j9gx
+  - https://security-tracker.debian.org/tracker/CVE-2025-6020
+  - https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2025-6020
+  - https://www.openwall.com/lists/oss-security/2025/06/17/1
+  - Commit 976c2007: https://github.com/linux-pam/linux-pam/commit/976c20079358d133514568fc7fd95c02df8b5773
+ .
 Author: Olivier Bal-Petre <olivier.bal-petre@ssi.gouv.fr>
+Author: Dmitry V. Levin <ldv@strace.io>
+Backported-by: hudeng <hudeng@deepin.org>
 Origin: upstream, https://github.com/linux-pam/linux-pam/releases/tag/v1.7.1
 Bug: https://github.com/linux-pam/linux-pam/security/advisories/GHSA-f9p8-gjr4-j9gx
-Bug-Debian: https://security-tracker.debian.org/tracker/CVE-2025-6020
+Bug-Deepin: https://cve.deepin.com/CVE-2025-6020
 Forwarded: not-needed
-Last-Update: 2025-02-03
-
----
- modules/pam_namespace/pam_namespace.c | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+Last-Update: 2025-02-04
 
 --- a/modules/pam_namespace/pam_namespace.c
 +++ b/modules/pam_namespace/pam_namespace.c
-@@ -1232,7 +1232,8 @@ static int protect_dir(const char *path,
+@@ -1229,8 +1229,8 @@ static int protect_dir(const char *path,
+ 		if (flags & O_NOFOLLOW) {
+ 			/* we are inside user-owned dir - protect */
  			if (protect_mount(dfd, p, idata) == -1)
  				goto error;
- 		} else if (st.st_uid != 0 || st.st_gid != 0 ||
+-		} else if (st.st_uid != 0 || st.st_gid != 0 ||
 -			(st.st_mode & S_IWOTH)) {
-+			(st.st_mode & S_IWOTH) ||
-+			(st.st_gid != 0 && (st.st_mode & S_IWGRP))) {
++		} else if (st.st_uid != 0 ||
++			(st.st_mode & (S_IWGRP|S_IWOTH))) {
  			/* do not follow symlinks on subdirectories */
  			flags |= O_NOFOLLOW;
  		}

--- a/debian/patches/cve_2025_6020.patch
+++ b/debian/patches/cve_2025_6020.patch
@@ -1,0 +1,37 @@
+Description: pam_namespace: fix privilege escalation via symlink attacks (CVE-2025-6020)
+ The protect_dir() function in pam_namespace may access user-controlled paths
+ without proper O_NOFOLLOW protection, allowing local users to elevate their
+ privileges via symlink attacks. This minimal backport improves the logic for
+ detecting when to enable O_NOFOLLOW protection and validates that only
+ root-owned directories without loose permissions can be followed.
+ .
+ The vulnerability occurs because the function may follow symlinks when
+ traversing paths that contain user-controlled components. The fix improves
+ the validation logic to ensure we only follow symlinks in directories that
+ are owned by root and not group-writable or world-writable.
+ .
+ This is a minimal backport fix for PAM 1.5.3, adapted from the more comprehensive
+ rewrite in PAM 1.7.1.
+Author: Olivier Bal-Petre <olivier.bal-petre@ssi.gouv.fr>
+Origin: upstream, https://github.com/linux-pam/linux-pam/releases/tag/v1.7.1
+Bug: https://github.com/linux-pam/linux-pam/security/advisories/GHSA-f9p8-gjr4-j9gx
+Bug-Debian: https://security-tracker.debian.org/tracker/CVE-2025-6020
+Forwarded: not-needed
+Last-Update: 2025-02-03
+
+---
+ modules/pam_namespace/pam_namespace.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/modules/pam_namespace/pam_namespace.c
++++ b/modules/pam_namespace/pam_namespace.c
+@@ -1232,7 +1232,8 @@ static int protect_dir(const char *path,
+ 			if (protect_mount(dfd, p, idata) == -1)
+ 				goto error;
+ 		} else if (st.st_uid != 0 || st.st_gid != 0 ||
+-			(st.st_mode & S_IWOTH)) {
++			(st.st_mode & S_IWOTH) ||
++			(st.st_gid != 0 && (st.st_mode & S_IWGRP))) {
+ 			/* do not follow symlinks on subdirectories */
+ 			flags |= O_NOFOLLOW;
+ 		}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ ftbfs-implicit-function-declaration
 0001-CVE-2024-10963.patch
 0001-CVE-2024-10041.patch
 support-sm3-hash-algorithm.patch
+cve_2025_6020.patch

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -1229,8 +1229,8 @@ static int protect_dir(const char *path, mode_t mode, int do_mkdir,
 			/* we are inside user-owned dir - protect */
 			if (protect_mount(dfd, p, idata) == -1)
 				goto error;
-		} else if (st.st_uid != 0 || st.st_gid != 0 ||
-			(st.st_mode & S_IWOTH)) {
+		} else if (st.st_uid != 0 ||
+			(st.st_mode & (S_IWGRP|S_IWOTH))) {
 			/* do not follow symlinks on subdirectories */
 			flags |= O_NOFOLLOW;
 		}


### PR DESCRIPTION
## Overview

This fixes CVE-2025-6020, a critical privilege escalation vulnerability in pam_namespace where user-controlled paths could be accessed without proper O_NOFOLLOW protection, allowing local users to gain root privileges via symlink attacks.

## Changes

- Backported fix from PAM 1.7.1 to 1.5.3
- Modified protect_dir() to check group-writable directories
- Added O_NOFOLLOW protection for non-root directories
- Added new patch: debian/patches/cve_2025_6020.patch
- Updated debian/changelog: version 1.5.3-9deepin9

## Vulnerability Details

- **CVE ID**: CVE-2025-6020
- **Severity**: HIGH (CVSS 7.8)
- **Attack Vector**: Local
- **Module**: pam_namespace
- **Risk**: Privilege escalation via symlink attacks and race conditions

The protect_dir() function in pam_namespace may access user-controlled paths without proper O_NOFOLLOW protection. This allows local users to elevate their privileges through carefully crafted symlinks.

## Technical Implementation

This is a minimal backport for PAM 1.5.3, adapted from the comprehensive fix in PAM 1.7.1. The patch:

1. Adds group-writable directory checking in the protect_dir() function
2. Enables O_NOFOLLOW protection for more cases where user-controlled paths are involved
3. Ensures only root-owned directories without loose permissions can be followed

## Testing

- Patch applies cleanly alongside all 27 existing patches
- No conflicts or warnings during patch application
- Validates compliance with single-CVE-per-patch policy

## Commits

- e04dbbb: fix: CVE-2025-6020 - pam_namespace privilege escalation via symlink attacks
- 02651fc: changelog: Add CVE-2025-6020 fix entry

## References

- Upstream Advisory: https://github.com/linux-pam/linux-pam/security/advisories/GHSA-f9p8-gjr4-j9gx
- Debian Tracker: https://security-tracker.debian.org/tracker/CVE-2025-6020
- PAM 1.7.1 Release: https://github.com/linux-pam/linux-pam/releases/tag/v1.7.1
- PAM Security Advisory: https://github.com/linux-pam/linux-pam/security/advisories

## Impact

This CVE is rated HIGH severity (CVSS 7.8) as it allows local privilege escalation. Urgent review and merge is recommended.